### PR TITLE
Try using token with git configuration

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -27,6 +27,11 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - name: Setting up a git credential helper
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global url."https://${TOKEN}:@github.com/".insteadOf "https://github.com/"
       - uses: julia-actions/setup-julia@0b9b1d2cd24245f151902702d8e73b3f6b910014 # v1.6.0
         with:
           version: ${{ matrix.version }}


### PR DESCRIPTION
I saw https://github.com/JuliaRegistries/RegistryCI.jl/issues/482; I'm not sure this will work, but we use something like this for a private registry w/ private packages. The token we pass is a secret with read/write access to the relevant packages; in this case, I'm not sure `GITHUB_TOKEN` has enough permissions. Ref https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token